### PR TITLE
🐛 Fixed build

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,2 @@
 export * from './types/booking';
 export * from './types/flights';
-export * from './Roles';


### PR DESCRIPTION
Small fix. Looks like tsc does not like enums in .d.ts files :grin: Roles can be now imported via `import { Roles } from "@secure-booking-service/common-types/Roles";`